### PR TITLE
add minimal version of node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 CLI tool for splitting a single CAR into multiple CARs from the comfort of your terminal.
 
 ## Install
+Make sure you have installed Node.js higher than v15.0.0.
 
 ```sh
 npm install -g carbites-cli


### PR DESCRIPTION
Carbites-cli is using the Stream Promises API which is only available from Node.js >= v15.0.0. If anyone is using Node.js < v15.0.0, it will throw exceptions like:
```
Cannot find module '/usr/local/lib/node_modules/stream/promises'
```

Therefore, adding some description to make it clear for developers who is trying to use carbites-cli. 